### PR TITLE
add do_cmd, and lyd2cmd_generator header

### DIFF
--- a/.github/workflows/actions-compile.yml
+++ b/.github/workflows/actions-compile.yml
@@ -28,6 +28,6 @@ jobs:
       - name: basic compilation check
         run : ldd bin/iproute2-sysrepo
       - name: basic test ip address like
-        run : bin/iproute2-sysrepo
+        run : bin/iproute2-sysrepo link
       - name: yanglint
         run : make check

--- a/src/iproute2_sysrepo.c
+++ b/src/iproute2_sysrepo.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
 /*
  * Authors:     Vincent Jardin, <vjardin@free.fr>
+ *              Ali Aqrabawi, <aaqrabaw@okdanetworks.com>
  *
  *              This program is free software; you can redistribute it and/or
  *              modify it under the terms of the GNU Affero General Public
@@ -9,6 +10,7 @@
  *              version.
  *
  * Copyright (C) 2024 Vincent Jardin, <vjardin@free.fr>
+ *               2024 okda netrworks, <contact@okdanetworks.com>
  */
 
 /* system includes */
@@ -23,6 +25,10 @@
 
 #include "utils.h"
 #include "ip_common.h"
+
+#ifndef LIBDIR
+#define LIBDIR "/usr/lib"
+#endif
 
 int preferred_family = AF_UNSPEC;
 int human_readable;
@@ -43,12 +49,73 @@ struct rtnl_handle rth = { .fd = -1 };
 
 const char *get_ip_lib_dir(void)
 {
-	abort();
+    const char *lib_dir;
+
+    lib_dir = getenv("IP_LIB_DIR");
+    if (!lib_dir)
+        lib_dir = LIBDIR "/ip";
+
+    return lib_dir;
+}
+
+static const struct cmd {
+    const char *cmd;
+    int (*func)(int argc, char **argv);
+} cmds[] = {
+        { "address",	do_ipaddr },
+        { "addrlabel",	do_ipaddrlabel },
+        { "maddress",	do_multiaddr },
+        { "route",	do_iproute },
+        { "rule",	do_iprule },
+        { "neighbor",	do_ipneigh },
+        { "neighbour",	do_ipneigh },
+        { "ntable",	do_ipntable },
+        { "ntbl",	do_ipntable },
+        { "link",	do_iplink },
+        { "l2tp",	do_ipl2tp },
+        { "fou",	do_ipfou },
+        { "ila",	do_ipila },
+        { "macsec",	do_ipmacsec },
+        { "tunnel",	do_iptunnel },
+        { "tunl",	do_iptunnel },
+        { "tuntap",	do_iptuntap },
+        { "tap",	do_iptuntap },
+        { "token",	do_iptoken },
+        { "tcpmetrics",	do_tcp_metrics },
+        { "tcp_metrics", do_tcp_metrics },
+        { "monitor",	do_ipmonitor },
+        { "xfrm",	do_xfrm },
+        { "mroute",	do_multiroute },
+        { "mrule",	do_multirule },
+        { "netns",	do_netns },
+        { "netconf",	do_ipnetconf },
+        { "vrf",	do_ipvrf},
+        { "sr",		do_seg6 },
+        { "nexthop",	do_ipnh },
+        { "mptcp",	do_mptcp },
+        { "ioam",	do_ioam6 },
+        { "stats",	do_ipstats },
+        { 0 }
+};
+
+static int do_cmd(const char *argv0, int argc, char **argv)
+{
+    const struct cmd *c;
+
+    for (c = cmds; c->cmd; ++c) {
+        if (matches(argv0, c->cmd) == 0)
+            return -(c->func(argc - 1, argv + 1));
+    }
+
+    return EXIT_FAILURE;
 }
 
 int
 main(int argc, char **argv) {
-	if (rtnl_open(&rth, 0) < 0)
-		return EXIT_FAILURE;
-	return do_ipaddr(argc-1, argv+1);
+    if (rtnl_open(&rth, 0) < 0)
+        return EXIT_FAILURE;
+
+    int ret = do_cmd(argv[1], argc - 1, argv + 1);
+    rtnl_close(&rth);
+    return ret;
 }

--- a/src/iproute2_sysrepo.c
+++ b/src/iproute2_sysrepo.c
@@ -112,6 +112,9 @@ static int do_cmd(const char *argv0, int argc, char **argv)
 
 int
 main(int argc, char **argv) {
+    if (argc < 1)
+        return EXIT_FAILURE;
+
     if (rtnl_open(&rth, 0) < 0)
         return EXIT_FAILURE;
 

--- a/src/lyd2cmd_generator.c
+++ b/src/lyd2cmd_generator.c
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+/*
+ * Authors:     Ali Aqrabawi, <aaqrbaw@okdanetworks.com>
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU Affero General Public
+ *              License Version 3.0 as published by the Free Software Foundation;
+ *              either version 3.0 of the License, or (at your option) any later
+ *              version.
+ *
+ * Copyright (C) 2024 Okda Networks, <aaqrbaw@okdanetworks.com>
+ */
+
+#include "lyd2cmd_generator.h"
+
+// not implemented yet
+struct cmd_args **generate_argv(struct lyd_node *change_node)
+{
+    static struct cmd_args *cmds[CMDS_ARRAY_SIZE] = {NULL};
+    return cmds;
+}

--- a/src/lyd2cmd_generator.h
+++ b/src/lyd2cmd_generator.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+#ifndef IPROUTE2_SYSREPO_LYD2CMD_GENERATOR_H
+#define IPROUTE2_SYSREPO_LYD2CMD_GENERATOR_H
+
+#include <libyang/libyang.h>
+
+#define CMDS_ARRAY_SIZE 1024
+
+/**
+ * @brief data struct to store the int argc,char **argv pair.
+ *
+ * this struct can be easily used by
+ * iproute2::do_cmd(argc,argv)
+ */
+struct cmd_args{
+  int argc;
+  char **argv;
+};
+
+/**
+ * @brief generate argc,argv commands out of the lyd_node (diff).
+ * this lyd_node can be obtained from sysrepo API sr_get_change_diff(session) or libyang's lyd_lyd_diff_tree()
+ *
+ * @param[in] node Data node diff to generate the argc, argv.
+ * @return Array of cmd_args struct.
+ */
+struct cmd_args** generate_argv(struct lyd_node *change_node);
+
+#endif// IPROUTE2_SYSREPO_LYD2CMD_GENERATOR_H


### PR DESCRIPTION
[+] added `do_cmd` function.
[+]  fixed `get_ip_lib_dir` as it was causing segfault on add/set/delete commands. 
[+] added header file of `lyd2cmd_gen`.


