### PR TITLE
cmdgen,make,gitignore: move oper_t struct and get_operation header to cmdgen.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ dkms.conf
 
 # local outputs
 bin/iproute2-sysrepo
+
+#vscode
+./vscode

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ dkms.conf
 bin/iproute2-sysrepo
 
 #vscode
-./vscode
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ clean:
 	rm -f $(IPR2_SR_LIB_OBJ) && \
 	rm -f $(BIN)/$(EXEC)
 
+clean_srmod:
+	@set -e; \
+	rm -f $(IPR2_SR_OBJ) && \
+	rm -f $(IPR2_SR_LIB_OBJ) && \
+	rm -f $(BIN)/$(EXEC)
+
 iproute2/config.mk:
 	@set -e; \
 	cd iproute2 && \

--- a/src/iproute2_sysrepo.c
+++ b/src/iproute2_sysrepo.c
@@ -347,12 +347,12 @@ int ip_sr_config_change_cb_prepare(const struct lyd_node *dnode)
 int ip_sr_config_change_cb_apply(const struct lyd_node *change_dnode)
 {
     int ret;
-    struct cmd_args **ipr2_cmds;
+    struct cmd_info **ipr2_cmds;
     if (change_dnode == NULL) {
         return SR_ERR_INVAL_ARG;
     }
 
-    ipr2_cmds = lyd2cmds_argv(change_dnode);
+    ipr2_cmds = lyd2cmds(change_dnode);
     if (ipr2_cmds == NULL){
         fprintf(stderr,
                 "%s: failed to generate commands for the change \n",

--- a/src/lib/change_cmdgen.c
+++ b/src/lib/change_cmdgen.c
@@ -113,13 +113,8 @@ char *strip_yang_iden_prefix(const char *input)
 
 oper_t get_operation(const struct lyd_node *dnode)
 {
-
     struct lyd_meta *next;
     const char *operation;
-    if (dnode == NULL){
-        fprintf(stderr,"Failed to extract change operaiton, lyd_node is NULL");
-        return UNKNOWN_OPR;
-    }
     LY_LIST_FOR(dnode->meta, next)
     {
         if (!strcmp("operation", next->name)) {
@@ -212,7 +207,7 @@ void parse_command(const char *command, int *argc, char ***argv)
     free(cmd_copy);
 }
 
-void add_command(char *cmd_line, struct cmd_args **cmds, int *cmd_idx,
+void add_command(char *cmd_line, struct cmd_info **cmds, int *cmd_idx,
                  char **oper2cmd_prefix, const struct lyd_node *start_dnode)
 {
     int argc;
@@ -223,7 +218,7 @@ void add_command(char *cmd_line, struct cmd_args **cmds, int *cmd_idx,
         free_argv(argv, argc);
         return;
     }
-    (cmds)[*cmd_idx] = malloc(sizeof(struct cmd_args));
+    (cmds)[*cmd_idx] = malloc(sizeof(struct cmd_info));
 
     if ((cmds)[*cmd_idx] == NULL) {
         fprintf(stderr, "Memory allocation failed\n");
@@ -237,12 +232,12 @@ void add_command(char *cmd_line, struct cmd_args **cmds, int *cmd_idx,
     free_argv(argv, argc);
 }
 
-struct cmd_args **lyd2cmds_argv(const struct lyd_node *change_node)
+struct cmd_info **lyd2cmds(const struct lyd_node *change_node)
 {
     char *result;
     int cmd_idx = 0;
     char cmd_line[CMD_LINE_SIZE] = {0};
-    struct cmd_args **cmds = malloc(CMDS_ARRAY_SIZE * sizeof(struct cmd_args *));
+    struct cmd_info **cmds = malloc(CMDS_ARRAY_SIZE * sizeof(struct cmd_info *));
     // Set all elements of the array to NULL
     for (int i = 0; i < CMDS_ARRAY_SIZE; i++) {
         cmds[i] = NULL;
@@ -289,7 +284,7 @@ struct cmd_args **lyd2cmds_argv(const struct lyd_node *change_node)
             startcmd_node = next;
             // check if the cmd is not empty (first cmd)
             if (cmd_line[0] != 0)
-                add_command(cmd_line, cmds, &cmd_idx, oper2cmd_prefix, next);
+                add_command(cmd_line, cmds, &cmd_idx, oper2cmd_prefix, startcmd_node);
 
             // prepare for new command
             op_val = get_operation(next);

--- a/src/lib/cmdgen.h
+++ b/src/lib/cmdgen.h
@@ -7,6 +7,17 @@
 #define CMDS_ARRAY_SIZE 1024
 
 /**
+ * @brief data struct to store cmd operation.
+ *
+ */
+typedef enum {
+    ADD_OPR,
+    DELETE_OPR,
+    UPDATE_OPR,
+    UNKNOWN_OPR,
+} oper_t;
+
+/**
  * @brief data struct to store the int argc,char **argv pair.
  *
  * this struct can be easily used by
@@ -34,6 +45,7 @@ struct cmd_args** lyd2cmds_argv(const struct lyd_node *change_node);
  * @param[in] node Data node diff to generate the argc, argv.
  * @return Array of cmd_args struct.
  */
-struct cmd_args* lyd2rollbackcmd_argv(const struct lyd_node *change_node);
+struct cmd_args* lyd2rollback_cmds(struct cmd_args **ipr2_cmds);
+oper_t get_operation(const struct lyd_node *dnode);
 
 #endif// IPROUTE2_SYSREPO_CMDGEN_H

--- a/src/lib/cmdgen.h
+++ b/src/lib/cmdgen.h
@@ -40,10 +40,10 @@ struct cmd_info** lyd2cmds(const struct lyd_node *change_node);
  * @brief convert change cmd info to rollback cmd info.
  *
  *
- * @param[in] cmd_info change cmd info to be converted
+ * @param[in] change_node lyd_node of change data.
  * @return cmd_info rollback cmd.
  */
-struct cmd_info* get_rollback_cmd(struct cmd_info *ipr2_cmds);
+struct cmd_info* lyd2rollback_cmd(const struct lyd_node *change_node);
 
 /**
  * @brief get the change operation from change lyd_node.

--- a/src/lib/cmdgen.h
+++ b/src/lib/cmdgen.h
@@ -18,34 +18,40 @@ typedef enum {
 } oper_t;
 
 /**
- * @brief data struct to store the int argc,char **argv pair.
- *
- * this struct can be easily used by
- * iproute2::do_cmd(argc,argv)
+ * @brief data struct to store command information.
  */
-struct cmd_args{
+struct cmd_info{
     int argc;
     char **argv;
-    const struct lyd_node *cmd_start_dnode;
+    const struct lyd_node *cmd_start_dnode; /** lyd change node where the command starts
+                                                ipr2gen:cmd-start) */
 };
 
 /**
- * @brief generate argc,argv commands out of the lyd_node (diff).
+ * @brief generate list of commands info from the lyd_node (diff).
  *
  *
- * @param[in] node Data node diff to generate the argc, argv.
- * @return Array of cmd_args struct.
+ * @param[in] change_node lyd_node of change data.
+ * @return cmd_info array.
  */
-struct cmd_args** lyd2cmds_argv(const struct lyd_node *change_node);
+struct cmd_info** lyd2cmds(const struct lyd_node *change_node);
 
 /**
- * @brief generate argc,argv rollback command out of the lyd_node (diff).
+ * @brief convert change cmd info to rollback cmd info.
  *
  *
- * @param[in] node Data node diff to generate the argc, argv.
- * @return Array of cmd_args struct.
+ * @param[in] cmd_info change cmd info to be converted
+ * @return cmd_info rollback cmd.
  */
-struct cmd_args* generate_rollback_cmds(struct cmd_args **ipr2_cmds);
+struct cmd_info* get_rollback_cmd(struct cmd_info *ipr2_cmds);
+
+/**
+ * @brief get the change operation from change lyd_node.
+ *
+ *
+ * @param[in] lyd_node change node.
+ * @return oper_t
+ */
 oper_t get_operation(const struct lyd_node *dnode);
 
 #endif// IPROUTE2_SYSREPO_CMDGEN_H

--- a/src/lib/cmdgen.h
+++ b/src/lib/cmdgen.h
@@ -45,7 +45,7 @@ struct cmd_args** lyd2cmds_argv(const struct lyd_node *change_node);
  * @param[in] node Data node diff to generate the argc, argv.
  * @return Array of cmd_args struct.
  */
-struct cmd_args* lyd2rollback_cmds(struct cmd_args **ipr2_cmds);
+struct cmd_args* generate_rollback_cmds(struct cmd_args **ipr2_cmds);
 oper_t get_operation(const struct lyd_node *dnode);
 
 #endif// IPROUTE2_SYSREPO_CMDGEN_H


### PR DESCRIPTION
cmdgen: move oper_t struct and get_operation header to cmdgen.h to allow using them in rollback code.
MakeFile: add option to clean sysrepo module only without cleaning iproute2
gitignore: to ignore .vscode/