### PR TITLE
iproute2-sysrepo,cmdgen: make sr_connection accessible by lib/ code

### DIFF
--- a/src/iproute2_sysrepo.c
+++ b/src/iproute2_sysrepo.c
@@ -77,7 +77,7 @@ static struct filter_util *filter_list;
 struct rtnl_handle rth = { .fd = -1 };
 
 /* sysrepo */
-static sr_session_ctx_t *sr_session;
+sr_session_ctx_t *sr_session;
 static sr_conn_ctx_t *sr_connection;
 static sr_subscription_ctx_t *sr_sub_ctx;
 static char *iproute2_ip_modules[] = { "iproute2-ip-link",

--- a/src/lib/change_cmdgen.c
+++ b/src/lib/change_cmdgen.c
@@ -12,11 +12,8 @@
  */
 
 #include <ctype.h>
-#include <bsd/string.h>
 
 #include "cmdgen.h"
-
-#define CMD_LINE_SIZE 1024
 
 char *yang_ext_map[] = {
         [CMD_START_EXT] = "cmd-start",

--- a/src/lib/cmdgen.h
+++ b/src/lib/cmdgen.h
@@ -3,8 +3,10 @@
 #define IPROUTE2_SYSREPO_CMDGEN_H
 
 #include <libyang/libyang.h>
+#include <bsd/string.h>
 
 #define CMDS_ARRAY_SIZE 1024
+#define CMD_LINE_SIZE 1024
 
 /**
  * extension to extension name map.


### PR DESCRIPTION
iproute2-sysrepo:  make sr_connection accessable by lib/ code
cmdgen: move bsd/string.h and CMD_LINE_SIZE to cmdgen.h to be used by rollback_cmdgen.c