### PR TITLE
cmdgen, yang: fix value_only_ext in cmd gen,

### DIFF
--- a/src/lib/change_cmdgen.c
+++ b/src/lib/change_cmdgen.c
@@ -336,11 +336,9 @@ struct cmd_info **lyd2cmds(const struct lyd_node *change_node)
             }
 
             // if value only extension, don't include the schema->name (key) in the command.
-            if (get_extension(VALUE_ONLY_EXT, next, NULL) == EXIT_SUCCESS)
-                goto next_iter;
-
+            if (get_extension(VALUE_ONLY_EXT, next, NULL) == EXIT_SUCCESS);
              // if arg_name extension, key will be set to the arg-name value.
-            if (get_extension(ARG_NAME_EXT, next, &key) == EXIT_SUCCESS) {
+            else if (get_extension(ARG_NAME_EXT, next, &key) == EXIT_SUCCESS) {
                 if (key == NULL) {
                     fprintf(stderr, "%s: ipr2cgen:arg-name extension found but failed to "
                                     "get the arg-name value for node \"%s\"\n",

--- a/yang/iproute2-ip-link.yang
+++ b/yang/iproute2-ip-link.yang
@@ -201,6 +201,7 @@ module iproute2-ip-link {
             }
             leaf admin-status{
                 description "set admin status for the link";
+                ipr2cgen:value-only;
                 type enumeration {
                     enum "up";
                     enum "down";
@@ -217,6 +218,7 @@ module iproute2-ip-link {
                 case process-id {
                     description "create the device in the network namespace associated with process";
                     leaf pid {
+                        ipr2cgen:arg-name "netns";
                         type uint64;
                         description "process id";
                     }
@@ -224,6 +226,7 @@ module iproute2-ip-link {
                 case name {
                     description "create the device in the network namespace associated with name NETNSNAME";
                     leaf netnsname {
+                        ipr2cgen:arg-name "netns";
                         type string;
                         description "network namespace name";
                     }
@@ -231,6 +234,7 @@ module iproute2-ip-link {
                 case file {
                     description "create the device in the network namespace associated with file NETNSFILE";
                     leaf netnsfile {
+                        ipr2cgen:arg-name "netns";
                         type string;
                         description "network namespace file";
                     }


### PR DESCRIPTION
value only was not added as the condition goto next iter and skip collecting the value.

also added correct yang ext to iproute2-ip-link.yang, admin-statue -> ipr2cgen:value-only
netns -> ipr2cmdgen:arg-name for all cases