### PR TITLE
yang: add support for ip netns.

### DIFF
--- a/src/iproute2_sysrepo.c
+++ b/src/iproute2_sysrepo.c
@@ -83,6 +83,7 @@ static sr_conn_ctx_t *sr_connection;
 static sr_subscription_ctx_t *sr_sub_ctx;
 static char *iproute2_ip_modules[] = { "iproute2-ip-link",
                                        "iproute2-ip-nexthop",
+                                       "iproute2-ip-netns",
                                        NULL }; // null terminator
 
 

--- a/tests/cases/test_ip_netns.sh
+++ b/tests/cases/test_ip_netns.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+#####################################################################
+# Testbed Script for Testing iproute2-sysrepo "ip netns" functionality
+#####################################################################
+# This script performs a series of tests on the iproute2-sysrepo
+# functionality related to IP netns manipulation. It verifies the
+# creation and deletion (netns has no update) of IP netnss by iproute2-sysrepo
+# using sysrepocfg commands and checks if the operations are
+# successful.
+#
+# Test Steps:
+# 1. Test creating netns
+# 2. Test deleting netns
+#####################################################################
+
+ret=0
+####################################################################
+# Test: Create IP netnss
+####################################################################
+echo "--------------------"
+echo "[1] Test netns CREATE"
+echo "---------------------"
+
+# Step 1: Add IP netnss to RUNNING data store
+sysrepocfg -d running --edit  tests/cases/test_ip_netns_data.xml || ret=$?
+# Check if sysrepocfg command failed
+if [ -n "$ret" ] && [ "$ret" -ne 0 ]; then
+    echo "TEST-ERROR: failed to create netnss in sysrepo datastore"
+    exit "$ret"
+fi
+
+# Step 2: Check if IP 2 is created
+if ip netns exec vpn10 echo >/dev/null 2>&1; then
+    echo "TEST-INFO: IP netns vpn10 created successfully (OK)"
+else
+    echo "TEST-ERROR: Failed to create IP netns vpn10 (FAIL)"
+    exit 1
+fi
+
+# Step 3: Check if IP testIf1 is created
+if ip netns exec vpn20 echo >/dev/null 2>&1; then
+    echo "TEST-INFO: IP netns vpn20 created successfully (OK)"
+else
+    echo "TEST-ERROR: Failed to create IP netns vpn20 (FAIL)"
+    exit 1
+fi
+sleep 0.2
+
+####################################################################
+# Test: Delete IP netnss
+####################################################################
+echo "--------------------"
+echo "[3] Test netns DELETE"
+echo "---------------------"
+
+# Step 1: delete data from sysrepo
+sysrepocfg -C startup -d running -m iproute2-ip-netns || ret=$?
+# Check if sysrepocfg command failed
+if [ -n "$ret" ] && [ "$ret" -ne 0 ]; then
+    echo "TEST-ERROR: failed to delete IP netnss from sysrepo"
+    exit "$ret"
+fi
+
+# Step 2: check if interface deleted by iproute2-sysrepo
+if ! ip netns exec vpn10 echo >/dev/null 2>&1 && ! ip netns exec vpn20 echo >/dev/null 2>&1; then
+    echo "TEST-INFO: IP netns vpn10 and vpn20 are deleted successfully (OK)"
+else
+    echo "TEST-ERROR: Failed to delete IP netns vpn10 and/or vpn20 (FAIL)"
+    exit 1
+fi
+
+
+
+# Exit with return value
+exit $ret
+#!/bin/bash
+
+#####################################################################
+# Testbed Script for Testing iproute2-sysrepo "ip netns" functionality
+#####################################################################
+# This script performs a series of tests on the iproute2-sysrepo
+# functionality related to IP netns manipulation. It verifies the
+# creation and deletion (netns has no update) of IP netnss by iproute2-sysrepo
+# using sysrepocfg commands and checks if the operations are
+# successful.
+#
+# Test Steps:
+# 1. Test creating netns
+# 2. Test deleting netns
+#####################################################################
+
+ret=0
+####################################################################
+# Test: Create IP netnss
+####################################################################
+echo "--------------------"
+echo "[1] Test netns CREATE"
+echo "---------------------"
+
+# Step 1: Add IP netnss to RUNNING data store
+sysrepocfg -d running --edit  tests/cases/test_ip_netns_data.xml || ret=$?
+# Check if sysrepocfg command failed
+if [ -n "$ret" ] && [ "$ret" -ne 0 ]; then
+    echo "TEST-ERROR: failed to create netnss in sysrepo datastore"
+    exit "$ret"
+fi
+
+# Step 2: Check if IP 2 is created
+if ip netns exec vpn10 echo >/dev/null 2>&1; then
+    echo "TEST-INFO: IP netns vpn10 created successfully (OK)"
+else
+    echo "TEST-ERROR: Failed to create IP netns vpn10 (FAIL)"
+    exit 1
+fi
+
+# Step 3: Check if IP testIf1 is created
+if ip netns exec vpn20 echo >/dev/null 2>&1; then
+    echo "TEST-INFO: IP netns vpn20 created successfully (OK)"
+else
+    echo "TEST-ERROR: Failed to create IP netns vpn20 (FAIL)"
+    exit 1
+fi
+sleep 0.2
+
+####################################################################
+# Test: Delete IP netnss
+####################################################################
+echo "--------------------"
+echo "[3] Test netns DELETE"
+echo "---------------------"
+
+# Step 1: delete data from sysrepo
+sysrepocfg -C startup -d running -m iproute2-ip-netns || ret=$?
+# Check if sysrepocfg command failed
+if [ -n "$ret" ] && [ "$ret" -ne 0 ]; then
+    echo "TEST-ERROR: failed to delete IP netnss from sysrepo"
+    exit "$ret"
+fi
+
+# Step 2: check if interface deleted by iproute2-sysrepo
+if ! ip netns exec vpn10 echo >/dev/null 2>&1 && ! ip netns exec vpn20 echo >/dev/null 2>&1; then
+    echo "TEST-INFO: IP netns vpn10 and vpn20 are deleted successfully (OK)"
+else
+    echo "TEST-ERROR: Failed to delete IP netns vpn10 and/or vpn20 (FAIL)"
+    exit 1
+fi
+
+
+
+# Exit with return value
+exit $ret

--- a/tests/cases/test_ip_netns_data.xml
+++ b/tests/cases/test_ip_netns_data.xml
@@ -1,0 +1,8 @@
+<netnses xmlns="urn:okda:iproute2:ip:netns">
+    <netns>
+        <name>vpn10</name>
+    </netns>
+    <netns>
+        <name>vpn20</name>
+    </netns>
+</netnses>

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -43,8 +43,10 @@ wait $sysrepo_pid
 
 # Check if the previous steps encountered any errors
 if [ $ret -ne 0 ]; then
-    echo "Error: One or more test scripts failed."
+    echo "TEST-ERROR: One or more test scripts failed. (FAIL)"
     exit $ret
+else
+   echo "TEST-INFO: All Tests Completed Successfully (PASS)"
 fi
 
 # Exit with return value

--- a/yang/iproute2-ip-link.yang
+++ b/yang/iproute2-ip-link.yang
@@ -4,6 +4,7 @@ module iproute2-ip-link {
     prefix "iplink";
 
     import iproute2-cmdgen-extensions { prefix ipr2cgen; }
+    import iproute2-ip-netns { prefix ipnetns; }
     //import ietf-inet-types { prefix inet; }
     //import ietf-yang-types { prefix yang; }
     organization
@@ -227,7 +228,7 @@ module iproute2-ip-link {
                     description "create the device in the network namespace associated with name NETNSNAME";
                     leaf netnsname {
                         ipr2cgen:arg-name "netns";
-                        type string;
+                        type ipnetns:netns-ref;
                         description "network namespace name";
                     }
                 }

--- a/yang/iproute2-ip-netns.yang
+++ b/yang/iproute2-ip-netns.yang
@@ -1,0 +1,55 @@
+module iproute2-ip-netns {
+    yang-version 1.1;
+    namespace "urn:okda:iproute2:ip:netns";
+    prefix "ipnetns";
+
+    import iproute2-cmdgen-extensions { prefix ipr2cgen; }
+
+    organization
+        "Okda Networks";
+
+    contact
+        "Author: Ali Aqrabawi
+        <aaqrabaw@okdanetworks.com>";
+
+    description
+        "This module contain the iproute2 network namesapce (ip netns) configurations,
+        this is module contains all IP-NETNS(8) related configs,
+        refer to https://manpages.debian.org/jessie/iproute2/ip-netns.8.en.html";
+
+    revision "2024-02-24" {
+        description "Revision 1";
+        reference
+            "YANG model for iproute2 ip network namespace case.";
+    }
+
+    typedef netns-ref {
+        type leafref {
+            path "/ipnetns:netnses/ipnetns:netns/ipnetns:name";
+        }
+        description
+            "This type is used by data models that need to reference
+            network namespaces.";
+    }
+
+    container netnses{
+        ipr2cgen:cmd-add "ip netns add";
+        ipr2cgen:cmd-delete "ip netns del";
+        ipr2cgen:cmd-update ""; // netsn has no update operation, but cmd-update is required.
+        description
+            "iproute2 netns configurations";
+        list netns{
+            ipr2cgen:cmd-start;
+            key "name";
+            description
+                "netns configuraton";
+            leaf name{
+                ipr2cgen:value-only;
+                description "network namespace name";
+                type string;
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
added yang module iproute2-ip-netns.
also updated iproute2-ip-link to use netns
as leafref in iproute2-ip-link:links/link/netns referncing iproute2-ip-netns:netnses/netns/name.