### PR TITLE
ip_nexthop,cmdgen: add group extension and code refactor for cmdgen

### DIFF
--- a/.github/workflows/actions-compile.yml
+++ b/.github/workflows/actions-compile.yml
@@ -77,7 +77,8 @@ jobs:
                   echo "Failed: did not exit with code 1."
                   exit 1
               fi
+      - name: yanglint
+        run: make check
       - name: run iproute2-sysrepo tests
         run : chmod +x tests/run_tests.sh && sudo ./tests/run_tests.sh
-      - name: yanglint
-        run : make check
+

--- a/src/lib/cmdgen.h
+++ b/src/lib/cmdgen.h
@@ -58,6 +58,12 @@ struct cmd_info{
 };
 
 /**
+ * free the all the cmd_info.
+ * @param cmds_info array of cmd_info struct.
+ */
+void free_cmds_info(struct cmd_info **cmds_info);
+
+/**
  * @brief generate list of commands info from the lyd_node (diff).
  *
  *

--- a/yang/iproute2-cmdgen-extensions.yang
+++ b/yang/iproute2-cmdgen-extensions.yang
@@ -70,5 +70,20 @@ module iproute2-cmdgen-extensions {
             on update cmd";
         argument "args-names";
     }
+    extension replace-on-update{
+        description
+            "instruct iproute2 to get all leafs in sysrepo, compare it with the changed leaf, and apply the diff.
+            typically used where iproute2 cmd require a replace for update, example tc filter, and ip nexthop group";
+    }
+    extension group-list-with-separator{
+        description
+            "instruct iproute2 to group all the list enteries together with the separator specified";
+    argument "separator";
+    }
+    extension group-leafs-values-separator{
+        description
+            "instruct iproute2 to group the leafs values inside the list/container to be groupd with separator specified";
+    argument "separator";
+    }
 
 }

--- a/yang/iproute2-ip-nexthop.yang
+++ b/yang/iproute2-ip-nexthop.yang
@@ -15,7 +15,6 @@ module iproute2-ip-nexthop {
         <aaqrabaw@okdanetworks.com>";
 
     description
-
         "This module contain the iproute2 'ip nexthop' configurations ,
         this is module contains all IP-NEXTHOP(8) related configs,
         refer to https://manpages.debian.org/experimental/iproute2/ip-nexthop.8.en.html";
@@ -97,14 +96,17 @@ module iproute2-ip-nexthop {
                     }
                 }
             }
-            list group {
-                key "id weight";
-                description "create a nexthop group. Group specification is id with an optional weight";
+        container group {
+            description "create a nexthop group. Group specification is id with an optional weight";
+            list nh {
+                key "id";
+                ipr2cgen:group-list-with-separator "/";
+                ipr2cgen:group-leafs-values-separator ",";
                 leaf id{
                     type leafref {
-                        path "../../id";
+                        path "../../../id";
                     }
-                    must ". != ../../id" {
+                    must ". != ../../../id" {
                         error-message "Cannot reference the current nexthop ID, you can use other nexthops ids";
                     }
                     description "specify the nexthop id you want to add to this next";
@@ -113,6 +115,7 @@ module iproute2-ip-nexthop {
                     description "nexthop weight for this member";
                     type uint16;
                 }
+            }
                 leaf type {
                     default "mpath";
                     type enumeration {


### PR DESCRIPTION
[+] added group extension to ip-nexthop and group separator 
[+] changed cmdgen logic to generate args for starcmd, this will allow us to change the lyd_node before passing to the args generator usefull for iproute replace action.