### PR TITLE
iproute2: lib/json_print.c patch to send its outputs to memory buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ IPR2_SR_OBJ = $(IPR2_SR_SRC:.c=.o)
 
 
 all: $(IPR2_SR_OBJ) $(IPR2_SR_LIB_OBJ) iproute2/config.mk
+	@echo "Checking if json_print patch is already applied..."
+	@if ! patch --dry-run --reverse --force -d iproute2 -p1 < ipr2_patches/json_print.patch; then \
+		echo "Applying json_print patch..."; \
+		patch -d iproute2 -p1 < ipr2_patches/json_print.patch || { echo "Patch failed"; true; }; \
+	else \
+		echo "json_print patch is already applied, skipping..."; \
+	fi
 	@set -e; \
 	for i in $(SUBDIRS); do \
 	$(MAKE) -C $$i || exit 1; done && \
@@ -43,6 +50,13 @@ all: $(IPR2_SR_OBJ) $(IPR2_SR_LIB_OBJ) iproute2/config.mk
 	@echo "Make complete"
 
 clean:
+	@echo "Checking if json_print patch is already applied..."
+	@if ! patch --dry-run --reverse --force -d iproute2 -p1 < ipr2_patches/json_print.patch; then \
+		echo "Patch wasn't applying, nothing to reverse..."; \
+	else \
+		echo "Reversing json_print patch..."; \
+		patch -R -d iproute2 -p1 < ipr2_patches/json_print.patch || { echo "Patch failed"; true; }; \
+	fi
 	@set -e; \
 	for i in $(SUBDIRS); do \
 	$(MAKE) -C $$i clean || exit 1; done && \

--- a/ipr2_patches/json_print.patch
+++ b/ipr2_patches/json_print.patch
@@ -1,0 +1,26 @@
+--- /lib/json_print.c	2024-03-01 19:01:32.645610624 -0500
++++ ipr2_patches/json_print_modified	2024-03-01 18:41:21.869658736 -0500
+@@ -11,12 +11,15 @@
+ #include "utils.h"
+ #include "json_print.h"
+ 
++FILE *j_stream;
++char json_buffer[1024 * 1024] = { 0 };
+ static json_writer_t *_jw;
+ 
+ static void __new_json_obj(int json, bool have_array)
+ {
+ 	if (json) {
+-		_jw = jsonw_new(stdout);
++		j_stream = fmemopen(json_buffer, sizeof(json_buffer), "w");
++		_jw = jsonw_new(j_stream);
+ 		if (!_jw) {
+ 			perror("json object");
+ 			exit(1);
+@@ -34,6 +37,7 @@
+ 		if (have_array)
+ 			jsonw_end_array(_jw);
+ 		jsonw_destroy(&_jw);
++		fclose(j_stream);
+ 	}
+ }

--- a/src/iproute2_sysrepo.c
+++ b/src/iproute2_sysrepo.c
@@ -84,6 +84,8 @@ static sr_subscription_ctx_t *sr_sub_ctx;
 static char *iproute2_ip_modules[] = { "iproute2-ip-link", "iproute2-ip-nexthop",
                                        "iproute2-ip-netns", NULL }; // null terminator
 
+extern char json_buffer[1024 * 1024];
+
 volatile int exit_application = 0;
 static jmp_buf jbuf;
 static int jump_set = 0;


### PR DESCRIPTION
Starting point to go with this implementation plan:
1. oper_data_cmdgen --> translates operational data sysrepo requests to iproute2 show commands
2. Outputs of show commands are stored in a memory buffer (json_buffer) instead of sending them to stdout (this PR).
3. Access the data once do_cmd is done and change json to lyd to be sent to sysrepo