### PR TITLE
blueprint: use mem output instead of stdout for json's handlers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ all: $(IPR2_SR_OBJ) $(IPR2_SR_LIB_OBJ) iproute2/config.mk
 	@echo "Patching conflicting symbols"
 	objcopy --redefine-sym print_linkinfo=br_print_linkinfo iproute2/bridge/link.o
 	objcopy --redefine-sym print_linkinfo=br_print_linkinfo iproute2/bridge/monitor.o
+	objcopy --redefine-sym new_json_obj=new_json_obj_donotuse iproute2/lib/json_print.o
+	objcopy --redefine-sym delete_json_obj=delete_json_obj_donotuse iproute2/lib/json_print.o
+	objcopy --redefine-sym new_json_obj_plain=new_json_obj_plain_donotuse iproute2/lib/json_print.o
+	objcopy --redefine-sym delete_json_obj_plain=delete_json_obj_plain_donotuse iproute2/lib/json_print.o
 	@echo ""
 	$(CC) -o $(BIN)/$(EXEC) $(IPR2_SR_OBJ) $(IPR2_SR_LIB_OBJ) `find iproute2/ip -name '*.[o]'` `find iproute2/bridge -name '*.[o]'` `find iproute2/tc -name '*.[o]'` `find iproute2/lib -name '*.[o]'` $(LDFLAGS)
 	@echo ""

--- a/src/lib/json_print2.c
+++ b/src/lib/json_print2.c
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * json_print2.c	 - memory ouput instead of stdout
+ *
+ * Authors:    Vincent Jardin, <vjardin@free.fr>
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "utils.h"
+#include "json_print.h"
+
+FILE *j_stream = NULL;
+char json_buffer[1024 * 1024] = { 0 };
+static json_writer_t *_jw;
+
+static void __new_json_obj_mem(int json, bool have_array)
+{
+	if (json) {
+		j_stream = fmemopen(json_buffer, sizeof(json_buffer), "w");
+		_jw = jsonw_new(j_stream);
+		if (!_jw) {
+			perror("json object");
+			exit(1);
+		}
+		if (pretty)
+			jsonw_pretty(_jw, true);
+		if (have_array)
+			jsonw_start_array(_jw);
+	}
+}
+
+static void __delete_json_obj_mem(bool have_array)
+{
+	if (_jw) {
+		if (have_array)
+			jsonw_end_array(_jw);
+		jsonw_destroy(&_jw);
+		fclose(j_stream);
+	}
+}
+
+void new_json_obj(int json)
+{
+	__new_json_obj_mem(json, true);
+}
+
+void delete_json_obj(void)
+{
+	__delete_json_obj_mem(true);
+}
+
+void new_json_obj_plain(int json)
+{
+	__new_json_obj_mem(json, false);
+}
+
+void delete_json_obj_plain(void)
+{
+	__delete_json_obj_mem(false);
+}
+

--- a/src/lib/json_print2.c
+++ b/src/lib/json_print2.c
@@ -17,47 +17,46 @@ static json_writer_t *_jw;
 
 static void __new_json_obj_mem(int json, bool have_array)
 {
-	if (json) {
-		j_stream = fmemopen(json_buffer, sizeof(json_buffer), "w");
-		_jw = jsonw_new(j_stream);
-		if (!_jw) {
-			perror("json object");
-			exit(1);
-		}
-		if (pretty)
-			jsonw_pretty(_jw, true);
-		if (have_array)
-			jsonw_start_array(_jw);
-	}
+    if (json) {
+        j_stream = fmemopen(json_buffer, sizeof(json_buffer), "w");
+        _jw = jsonw_new(j_stream);
+        if (!_jw) {
+            perror("json object");
+            exit(1);
+        }
+        if (pretty)
+            jsonw_pretty(_jw, true);
+        if (have_array)
+            jsonw_start_array(_jw);
+    }
 }
 
 static void __delete_json_obj_mem(bool have_array)
 {
-	if (_jw) {
-		if (have_array)
-			jsonw_end_array(_jw);
-		jsonw_destroy(&_jw);
-		fclose(j_stream);
-	}
+    if (_jw) {
+        if (have_array)
+            jsonw_end_array(_jw);
+        jsonw_destroy(&_jw);
+        fclose(j_stream);
+    }
 }
 
 void new_json_obj(int json)
 {
-	__new_json_obj_mem(json, true);
+    __new_json_obj_mem(json, true);
 }
 
 void delete_json_obj(void)
 {
-	__delete_json_obj_mem(true);
+    __delete_json_obj_mem(true);
 }
 
 void new_json_obj_plain(int json)
 {
-	__new_json_obj_mem(json, false);
+    __new_json_obj_mem(json, false);
 }
 
 void delete_json_obj_plain(void)
 {
-	__delete_json_obj_mem(false);
+    __delete_json_obj_mem(false);
 }
-


### PR DESCRIPTION
It is a dirty patch, using link time instead of patching the C code. It works by renaming the iproute2's symbols that need to be patched. A proper fix should be upstreamed into iproute2.