### PR TITLE
iproute-sysrepo: update code structure to allow for oper_data support

### DIFF
--- a/src/iproute2_sysrepo.c
+++ b/src/iproute2_sysrepo.c
@@ -41,6 +41,7 @@
 
 /* sysrepo */
 #include "lib/cmdgen.h"
+#include "lib/oper_data.h"
 #include <sysrepo.h>
 
 #ifndef LIBDIR
@@ -81,10 +82,15 @@ struct rtnl_handle rth = { .fd = -1 };
 sr_session_ctx_t *sr_session;
 static sr_conn_ctx_t *sr_connection;
 static sr_subscription_ctx_t *sr_sub_ctx;
-static char *iproute2_ip_modules[] = { "iproute2-ip-link", "iproute2-ip-nexthop",
-                                       "iproute2-ip-netns", NULL }; // null terminator
-
-extern char json_buffer[1024 * 1024];
+/**
+ * Struct tp store yang modules names and their operational data subscription path.
+ */
+struct yang_module {
+    const char *module; // Stores Module name
+    const char *oper_pull_path; // Stores operational pull subscription path
+} ipr2_ip_modules[] = { { "iproute2-ip-link", "/iproute2-ip-link:links" },
+                        { "iproute2-ip-nexthop", "/iproute2-ip-nexthop:nexthops" },
+                        { "iproute2-ip-netns", "/iproute2-ip-netns:netnses" } };
 
 volatile int exit_application = 0;
 static jmp_buf jbuf;
@@ -98,7 +104,7 @@ static void exit_cb(void)
 
 static void sigint_handler(__attribute__((unused)) int signum)
 {
-    printf("Sigint called, exiting...\n");
+    fprintf(stdout, "\nSigint called, exiting...\n");
     exit_application = 1;
 }
 
@@ -441,33 +447,97 @@ int ip_sr_config_change_cb(sr_session_ctx_t *session, uint32_t sub_id, const cha
     return ret;
 }
 
+int ipr2_oper_get_items_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name,
+                           const char *xpath, const char *request_xpath, uint32_t request_id,
+                           struct lyd_node **parent, void *private_data)
+{
+    int ret;
+    char *ipr2_show_cmd, **argv;
+    int argc;
+    const struct ly_ctx *ly_ctx;
+
+    (void)session;
+    (void)sub_id;
+    (void)request_xpath;
+    (void)request_id;
+    (void)private_data;
+
+    ipr2_show_cmd = get_module_sh_startcmd(module_name);
+
+    parse_command(ipr2_show_cmd, &argc, &argv);
+    jump_set = 1;
+    if (setjmp(jbuf)) {
+        // iproute2 exited, reset jump, and set exit callback.
+        atexit(exit_cb);
+        ret = SR_ERR_CALLBACK_FAILED;
+        goto exit_check_done;
+    }
+    ret = do_cmd(argc, argv);
+exit_check_done:
+    if (ret != EXIT_SUCCESS) {
+        fprintf(stderr, "%s: iproute2 command failed, cmd = ", __func__);
+        print_cmd_line(argc, argv);
+        ret = SR_ERR_CALLBACK_FAILED;
+    } else {
+        ret = sr_set_oper_data_items(session, module_name, parent);
+    }
+    jump_set = 0;
+    return ret;
+}
+
 static void sr_subscribe_config()
 {
-    char **ip_module = iproute2_ip_modules;
     int ret;
-    fprintf(stdout, "Subscribing to sysrepo modules config updates:\n");
-    while (*ip_module != NULL) {
-        ret = sr_module_change_subscribe(sr_session, *ip_module, NULL, ip_sr_config_change_cb, NULL,
-                                         0, SR_SUBSCR_DEFAULT, &sr_sub_ctx);
-        if (ret != SR_ERR_OK)
-            fprintf(stderr, "%s: failed to subscribe to module (%s): %s\n", __func__, *ip_module,
-                    sr_strerror(ret));
-        else
-            fprintf(stdout, "%s: successfully subscribed to module (%s)\n", __func__, *ip_module);
+    fprintf(stdout, "Subscribing to iproute2 modules config changes:\n");
 
-        ++ip_module;
+    /* subscribe to ip modules */
+    for (size_t i = 0; i < sizeof(ipr2_ip_modules) / sizeof(ipr2_ip_modules[0]); i++) {
+        ret = sr_module_change_subscribe(sr_session, ipr2_ip_modules[i].module, NULL,
+                                         ip_sr_config_change_cb, NULL, 0, SR_SUBSCR_DEFAULT,
+                                         &sr_sub_ctx);
+        if (ret != SR_ERR_OK)
+            fprintf(stderr, "%s: Failed to subscribe to module (%s) config changes: %s\n", __func__,
+                    ipr2_ip_modules[i].module, sr_strerror(ret));
+        else
+            fprintf(stdout, "%s: Successfully subscribed to module (%s) config changes\n", __func__,
+                    ipr2_ip_modules[i].module);
     }
-    /* loop until ctrl-c is pressed / SIGINT is received */
-    signal(SIGINT, sigint_handler);
-    signal(SIGPIPE, SIG_IGN);
-    while (!exit_application) {
-        sleep(1);
+
+    /* TODO subscribe to bridge modules */
+    /* TODO subscribe to TC modules */
+}
+
+static void sr_subscribe_operational_pull()
+{
+    int ret;
+    fprintf(stdout, "Subscribing to iproute2 modules operational data pull requests:\n");
+    /* subscribe to ip modules */
+    for (size_t i = 0; i < sizeof(ipr2_ip_modules) / sizeof(ipr2_ip_modules[0]); i++) {
+        ret = sr_oper_get_subscribe(sr_session, ipr2_ip_modules[i].module,
+                                    ipr2_ip_modules[i].oper_pull_path, ipr2_oper_get_items_cb, NULL,
+                                    0, &sr_sub_ctx);
+        if (ret != SR_ERR_OK)
+            fprintf(stderr,
+                    "%s: Failed to subscribe to module (%s) operational data pull requests: %s\n",
+                    __func__, ipr2_ip_modules[i].module, sr_strerror(ret));
+        else
+            fprintf(stdout,
+                    "%s: Successfully subscribed to module (%s) operational data pull requests\n",
+                    __func__, ipr2_ip_modules[i].module);
     }
+
+    /* TODO subscribe to bridge modules */
+    /* TODO subscribe to TC modules */
 }
 
 int sysrepo_start()
 {
     int ret;
+
+    ++json; /* set iproute2 to format its print outputs in json */
+    ++show_details; /* set iproute2 to include details in its print outputs */
+    ++show_stats; /* set iproute2 to include stats in its print outputs */
+
     ret = sr_connect(SR_CONN_DEFAULT, &sr_connection);
     if (ret != SR_ERR_OK) {
         fprintf(stderr, "%s: sr_connect(): %s\n", __func__, sr_strerror(ret));
@@ -481,8 +551,18 @@ int sysrepo_start()
         goto cleanup;
     }
     sr_subscribe_config();
+    sr_subscribe_operational_pull();
+
+    /* loop until ctrl-c is pressed / SIGINT is received */
+    signal(SIGINT, sigint_handler);
+    signal(SIGPIPE, SIG_IGN);
+    while (!exit_application) {
+        sleep(1);
+    }
 
 cleanup:
+    if (sr_sub_ctx)
+        sr_unsubscribe(sr_sub_ctx);
     if (sr_session)
         sr_session_stop(sr_session);
     if (sr_connection)

--- a/src/lib/cmdgen.h
+++ b/src/lib/cmdgen.h
@@ -34,4 +34,12 @@ void free_cmds_info(struct cmd_info **cmds_info);
  */
 struct cmd_info **lyd2cmds(const struct lyd_node *change_node);
 
+/**
+ * parse the command line and convert it to argc, argv
+ * @param [in]  command command line string "ip link add ..."
+ * @param [out] argc parsed argv count
+ * @param [out] argv parsed argv
+ */
+void parse_command(const char *command, int *argc, char ***argv);
+
 #endif // IPROUTE2_SYSREPO_CMDGEN_H

--- a/src/lib/oper_data.c
+++ b/src/lib/oper_data.c
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+/*
+ * Authors:     Amjad Daraiseh, adaraiseh@okdanetworks.com>
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU Affero General Public
+ *              License Version 3.0 as published by the Free Software Foundation;
+ *              either version 3.0 of the License, or (at your option) any later
+ *              version.
+ *
+ * Copyright (C) 2024 Okda Networks, <contact@okdanetworks.com>
+ */
+
+#include "oper_data.h"
+#include "cmdgen.h"
+
+/**
+ * Struct store yang modules names and their iproute2 show cmd start.
+ */
+struct module_sh_cmdstart {
+    const char *module_name; // Stores Module name
+    const char *showcmd_start; // Store iproute2 show command related to the module
+} ipr2_sh_cmdstart[] = { { "iproute2-ip-link", "ip link show" },
+                         { "iproute2-ip-nexthop", "ip nexthop show" },
+                         { "iproute2-ip-netns", "ip netns show" } };
+
+/**
+ * Wrap a JSON array in a JSON object with a specified key.
+ * 
+ * @param json_array The JSON array to wrap.
+ * @param key The key under which to wrap the JSON array.
+ * @return A new string representing the wrapped JSON object. The caller is responsible for freeing this memory.
+ */
+char *wrap_json_array(const char *json_array, const char *key)
+{
+    // Calculate the length of the new JSON string
+    size_t new_json_length = strlen(json_array) + strlen(key) +
+                             4; // Extra 4 chars for the two braces and two quotation marks
+    char *wrapped_json = malloc(new_json_length + 1); // +1 for the null terminator
+
+    if (!wrapped_json) {
+        fprintf(stderr, "Memory allocation failed\n");
+        return NULL;
+    }
+
+    // Construct the new JSON string
+    sprintf(wrapped_json, "{\"%s\":%s}", key, json_array);
+
+    return wrapped_json;
+}
+
+char *get_module_sh_startcmd(const char *module_name)
+{
+    char showcmd[CMD_LINE_SIZE] = { 0 };
+
+    /* convert module name to show cmd */
+    for (size_t i = 0; i < sizeof(ipr2_sh_cmdstart) / sizeof(ipr2_sh_cmdstart[0]); i++) {
+        if (strcmp(module_name, ipr2_sh_cmdstart[i].module_name) == 0) {
+            strlcat(showcmd, ipr2_sh_cmdstart[i].showcmd_start, sizeof(showcmd));
+            break;
+        }
+    }
+
+    if (showcmd == NULL) {
+        return NULL;
+    }
+    fprintf(stdout, "show cmd: %s\n", showcmd);
+
+    return strdup(showcmd);
+}
+
+int sr_set_oper_data_items(sr_session_ctx_t *session, const char *module_name,
+                           struct lyd_node **parent)
+{
+    const struct ly_ctx *ly_ctx;
+
+    char *schema = NULL;
+    const struct lys_module *module;
+    ly_ctx = sr_acquire_context(sr_session_get_connection(session));
+
+    /* get the requested module yang schema */
+    module = ly_ctx_get_module_implemented(ly_ctx, module_name);
+
+    /* TODO update the module leafs from json_buffer */
+
+cleanup:
+    sr_release_context(sr_session_get_connection(session));
+    return SR_ERR_OK;
+}

--- a/src/lib/oper_data.h
+++ b/src/lib/oper_data.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+#ifndef IPROUTE2_SYSREPO_OPER_DATA_H
+#define IPROUTE2_SYSREPO_OPER_DATA_H
+
+#include <sysrepo.h>
+#include <sysrepo/xpath.h>
+
+extern char json_buffer[1024 * 1024]; /* holds iproute2 show commands json outputs */
+
+char *get_module_sh_startcmd(const char *module_name);
+int sr_set_oper_data_items(sr_session_ctx_t *session, const char *module_name,
+                           struct lyd_node **parent);
+
+#endif // IPROUTE2_SYSREPO_OPER_DATA_H


### PR DESCRIPTION
[+] iproute2-sysrepo: change iproute2_ip_modules from a char arrary to a struct to allow adding modules operational subscription path.
[+] iproute2-sysrepo: add operational data subscription functions (sr_subscribe_operational_pull and ipr2_oper_get_items_cb)
[+] iproute2-sysrepo: move the wait for signal loop outside sr_subscribe_config to allow adding new subscription
[+] cmdgen: externlize parse_command to be able to use it for operational data iproute2 cmd parsing
[+] oper_data: set initial code structure