### PR TITLE
cmdgen: resolved cmds dependencies.

### DIFF
--- a/tests/cases/test_ip_link.sh
+++ b/tests/cases/test_ip_link.sh
@@ -108,12 +108,7 @@ echo "--------------------"
 echo "[3] Test Link DELETE"
 echo "---------------------"
 
-# step 1: work arround to delete the vlan10 first
-sysrepocfg -C  tests/cases/test_ip_link_data2.xml -d running
-sleep 0.1
-sysrepocfg -d running --edit  tests/cases/test_ip_link_data2.xml || ret=$?
-
-# Step 2: delete testif0 and testif1 from sysrepo
+# Step 1: delete vlan10, testif0 and testif1 from sysrepo
 sysrepocfg -C startup -d running -m iproute2-ip-link || ret=$?
 # Check if sysrepocfg command failed
 if [ -n "$ret" ] && [ "$ret" -ne 0 ]; then
@@ -121,7 +116,7 @@ if [ -n "$ret" ] && [ "$ret" -ne 0 ]; then
     exit "$ret"
 fi
 
-# Step 3: check if interface deleted by iproute2-sysrepo
+# Step 2: check if interface deleted by iproute2-sysrepo
 if ! ip link show testIf0 >/dev/null 2>&1 && ! ip link show testIf1 >/dev/null 2>&1; then
     echo "TEST-INFO: IP links testIf0 and testIf1 are deleted successfully (OK)"
 else

--- a/yang/iproute2-ip-link.yang
+++ b/yang/iproute2-ip-link.yang
@@ -1,7 +1,7 @@
 module iproute2-ip-link {
     yang-version 1.1;
     namespace "urn:okda:iproute2:ip:link";
-    prefix "iplink";
+    prefix iplink;
 
     import ietf-yang-types { prefix yang;}
     import iproute2-cmdgen-extensions { prefix ipr2cgen; }
@@ -149,7 +149,7 @@ module iproute2-ip-link {
         description "ip-link - network device configuration";
         list vrf{
             ipr2cgen:cmd-start;
-            key "name table";
+            key "name";
             leaf name {
                 ipr2cgen:after-node-add-static-arg "type vrf";
                 type string;
@@ -200,7 +200,7 @@ module iproute2-ip-link {
             leaf master{
                 ipr2cgen:on-node-delete "nomaster";
                 type link-ref;
-                description "add the interface to vrf";
+                description "add the link to master link";
                 must "../master != ../name" {
                     error-message "cannot use same link as master link!";
                 }
@@ -391,13 +391,13 @@ module iproute2-ip-link {
             }
             container bond_slave {
                 ipr2cgen:add-static-arg "type bond_slave";
-                when "../master";
-                must "/links/link[name=current()/../master]/type = 'iplink:bond'" {
-                    error-message "blond_slave can only be confirgured if the link is part of bonding
-                    (has a master link or type 'bond') ";
-                }
+                when "../master and /links/link[name=current()/../master]/type = 'iplink:bond'";
                 description "set additional bonding related to link with master bond link";
                 leaf queue_id{
+                    must "/links/link[name=current()/../../master]/type = 'iplink:bond'" {
+                        error-message "queue_id can only be confirgured if the link is part of bonding
+                        (has a master link or type 'bond') ";
+                    }
                     type uint16;
                     description "ID - set the slave's queue ID (a 16bit unsigned value)";
                 }


### PR DESCRIPTION
before generating cmds, we create a sorted changed_node, and generate cmds from that sorted change.
the sort is based on leafref, if the startcmd is add the leafref node will be instered before, if the startcmd is delete it will be instered before the leafref.