### PR TITLE
oper:config_load:bugfix: validate stop-if json data before processing it

### DIFF
--- a/src/lib/oper_data.c
+++ b/src/lib/oper_data.c
@@ -574,6 +574,14 @@ int process_node(const struct lysc_node *s_node, json_object *json_obj, uint16_t
             free(term_vals);
         }
 
+        if (term_jobj == NULL) {
+            fprintf(stderr,
+                    "%s: Error reading schema node \"%s\" ipr2cgen:oper-stop-if extension,"
+                    " the extension value has a bad json format\n",
+                    __func__, s_node->name);
+            return EXIT_FAILURE;
+        }
+
         if (terminate_processing(json_obj, term_jobj)) {
             s_node = (*parent_data_node)->schema->next;
             return EXIT_FAILURE;


### PR DESCRIPTION
fix for #83 